### PR TITLE
Adapted the circleci test-summary config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,9 @@ jobs:
             - "node_modules"
       - run:
           name: Running tests
-          command: npm run test
-      - store_artifacts:
-          path: test-reports/
-          destination: jest
+          command: npm run test -- --ci --reporters=default --reporters=jest-junit
+          environment:
+              JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
+      - store_test_results:
+          path: reports/junit
 

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ typings/
 
 #DynamoDB Local files
 .dynamodb/
+
+# test reports
+reports/

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+{
+  reporters: [ "default", "jest-junit" ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5841,6 +5841,18 @@
         "throat": "^4.0.0"
       }
     },
+    "jest-junit": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-6.4.0.tgz",
+      "integrity": "sha512-GXEZA5WBeUich94BARoEUccJumhCgCerg7mXDFLxWwI2P7wL3Z7sGWk+53x343YdBLjiMR9aD/gYMVKO+0pE4Q==",
+      "dev": true,
+      "requires": {
+        "jest-validate": "^24.0.0",
+        "mkdirp": "^0.5.1",
+        "strip-ansi": "^4.0.0",
+        "xml": "^1.0.1"
+      }
+    },
     "jest-leak-detector": {
       "version": "24.8.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz",
@@ -10685,6 +10697,12 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "css-loader": "^2.1.1",
     "html-webpack-plugin": "^3.2.0",
     "jest": "^24.8.0",
+    "jest-junit": "^6.4.0",
     "mini-css-extract-plugin": "^0.6.0",
     "node-sass": "^4.12.0",
     "react-hot-loader": "^4.6.0",


### PR DESCRIPTION
In this commit I adapted the circle ci configuration to store the test
results as that and not as artifacts. This should enable me to see the
test summary in circle ci.