### PR TITLE
Folable Menu

### DIFF
--- a/src/CoNu.jsx
+++ b/src/CoNu.jsx
@@ -5,7 +5,6 @@ import WebFont from 'webfontloader';
 import './scss/main.scss';
 
 import UrlBasedContentSwitcher from './UrlBasedContentSwitcher';
-import Logo from '../assets/images/conu-logo.svg';
 
 
 WebFont.load({
@@ -18,10 +17,6 @@ class CoNu extends React.PureComponent {
 	render() {
 		return (
 			<main className="conu">
-
-				<header className="conu__header">
-					<img src={ Logo } className="conu__logo" />
-				</header>
 
 				<UrlBasedContentSwitcher />
 

--- a/src/RedirectNotice.jsx
+++ b/src/RedirectNotice.jsx
@@ -2,23 +2,33 @@ import React from 'react';
 
 import Btn from './Btn';
 
+import Logo from '../assets/images/conu-logo.svg';
+
 
 const RedirectNotice = () =>
-	<div className="redirect-notice">
+	<>
+		<header className="conu__header">
+			<img
+				src={ Logo }
+				className="conu__logo conu__logo--not-interactive" />
+		</header>
 
-		<h2 className="redirect-notice__header">It's official!</h2>
+		<div className="redirect-notice">
 
-		<p className="redirect-notice__text">
-			Conu moved to it's now official website!
-		</p>
+			<h2 className="redirect-notice__header">It's official!</h2>
 
-		<a href="https://conu.app/" className="decoration-none">
-			<Btn>
-					Play at conu.app
-			</Btn>
-		</a>
+			<p className="redirect-notice__text">
+				Conu moved to it's now official website!
+			</p>
 
-	</div>
+			<a href="https://conu.app/" className="decoration-none">
+				<Btn>
+						Play at conu.app
+				</Btn>
+			</a>
+
+		</div>
+	</>
 
 export default RedirectNotice;
 

--- a/src/scss/conu.scss
+++ b/src/scss/conu.scss
@@ -22,6 +22,64 @@ $conu-padding: 0.4rem;
 	&__logo {
 		width: 7.9rem;
 		height: 7.9rem;
+
+		cursor: pointer;
+
+		&--not-interactive {
+			cursor: initial;
+		}
 	}
+
+	&__menu-wrapper {
+		position: relative;
+
+		width: 12rem;
+		overflow: hidden;
+
+		transition-property: width, opacity;
+		transition-duration: .3s;
+		transition-timing-function: ease-out;
+
+		&--collapsed {
+			width: 0;
+			opacity: 0;
+
+			transition-timing-function: ease-in;
+		}
+	}
+}
+
+.menu {
+	position: absolute;
+	top: 0;
+	right: 0;
+
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+
+	width: 12rem;
+	height: 7.9rem;
+	padding: 1rem;
+
+	text-align: left;
+}
+
+.btn--menu-item {
+	font-size: 1.5rem;
+
+		// &:before {
+		// 	content: "";
+		// 	display: inline-block;
+    //
+		// 	width: 0.6em;
+		// 	height: 0.6em;
+		// 	margin-right: 0.05em;
+		// 	margin-bottom: 0.03em;
+    //
+		// 	background-image: url( ../../assets/images/arrow.svg );
+		// 	background-size: 100% 100%;
+		// 	background-repeat: no-repeat;
+		// }
 }
 

--- a/src/scss/game.scss
+++ b/src/scss/game.scss
@@ -26,14 +26,6 @@
 	}
 }
 
-.btn--new-game {
-	@extend .btn--single-line;
-
-	width: $cell-width * 5 + $cell-v-spacing * 4;
-
-	margin-bottom: 2rem;
-}
-
 .btn-roll-over {
 	position: relative;
 	perspective: 800px;


### PR DESCRIPTION
In this commit I implemented a small foldable menu, to provide a better place
for the 'New Game' button and thus have it not break the layout anymore.

This was quite the act. I moved the code for the header into the `Game.jsx` and
`RedirectNotice.jsx` component, as these components now have different headers,
one with the foldable menu, the other one without. (It would not make sense to
start a new game when you are just seeing the redirect notice.)
Moving the header with the foldable menu into the GameLoader component had the
advantage that I didn't need to install a centralized state management. I can
just directly call the function to start a new game inside the GameLoader when
the user clicks on the 'New Game' button in the foldable menu. This however
makes the GameLoader quite the extensive component as it more or less managaes
all the state there currently is. I hope to move to a centralized state
management like redux in the future.

To make for nicer transitions / loading information I build in a distinction
between initial load `appLoading` and a consecutive load `newGameLoading`. This
way I can easily implement a loading screen in the future. But when the user
starts a new game, not everything is hidden behind a loading screen again. Makes
for the smoother experience IMO.

I also put in some timeout logic to hide away the menu after the app has loaded
and after the user started a new game. This way the menu collapses on its own to
be in a more aesthetic state. The menu is visible some time after the load as
this tells the user where to find it. I didn't want to label anything or put
some hamburger menu anywhere as it would break the clean design of the game.

I removed the old 'New Game' button and its scss code.